### PR TITLE
Added ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[ssh_connection]
+# (string) Extra exclusive to the SSH CLI.
+ssh_extra_args="-oServerAliveInterval=30"


### PR DESCRIPTION
Added ansible.cfg to rsolve timeout error for ssh connection during collect results job run.
We have noticed that our collect results job gets terminated due to timeout, that is because when there is a ssh connection issue in one of the server, it gets hang resulting timeout.